### PR TITLE
Add music metadata + `<res>` audio attributes to DIDL-Lite

### DIFF
--- a/services/avtransport/avtransport.go
+++ b/services/avtransport/avtransport.go
@@ -29,6 +29,20 @@ type MediaItem struct {
 	ContentType  string
 	Seekable     bool
 	Duration     time.Duration
+
+	// Audio / music metadata. Emitted into DIDL-Lite when non-zero.
+	// Renderers use these to populate their displays (cover art, artist,
+	// album, sample-rate / bit-depth readouts) and as hints about the
+	// underlying stream.
+	Artist          string
+	Album           string
+	AlbumArtURI     string
+	TrackNumber     int
+	Size            int64
+	Bitrate         int // bytes/sec, per DIDL-Lite res@bitrate
+	SampleFrequency int // Hz
+	BitsPerSample   int
+	NrAudioChannels int
 }
 
 // TransportInfo is the information returned by GetTransportInfo

--- a/services/avtransport/requestbuilders.go
+++ b/services/avtransport/requestbuilders.go
@@ -148,22 +148,32 @@ type didLLite struct {
 }
 
 type didLLiteItem struct {
-	SecCaptionInfo   *secCaptionInfo   `xml:"sec:CaptionInfo,omitempty"`
-	SecCaptionInfoEx *secCaptionInfoEx `xml:"sec:CaptionInfoEx,omitempty"`
-	XMLName          xml.Name          `xml:"item"`
-	DCtitle          string            `xml:"dc:title"`
-	UPNPClass        string            `xml:"upnp:class"`
-	ID               string            `xml:"id,attr"`
-	ParentID         string            `xml:"parentID,attr"`
-	Restricted       string            `xml:"restricted,attr"`
-	ResNode          []resNode         `xml:"res"`
+	SecCaptionInfo       *secCaptionInfo   `xml:"sec:CaptionInfo,omitempty"`
+	SecCaptionInfoEx     *secCaptionInfoEx `xml:"sec:CaptionInfoEx,omitempty"`
+	XMLName              xml.Name          `xml:"item"`
+	DCtitle              string            `xml:"dc:title"`
+	DCcreator            string            `xml:"dc:creator,omitempty"`
+	UPNPartist           string            `xml:"upnp:artist,omitempty"`
+	UPNPalbum            string            `xml:"upnp:album,omitempty"`
+	UPNPoriginalTrackNum int               `xml:"upnp:originalTrackNumber,omitempty"`
+	UPNPalbumArtURI      string            `xml:"upnp:albumArtURI,omitempty"`
+	UPNPClass            string            `xml:"upnp:class"`
+	ID                   string            `xml:"id,attr"`
+	ParentID             string            `xml:"parentID,attr"`
+	Restricted           string            `xml:"restricted,attr"`
+	ResNode              []resNode         `xml:"res"`
 }
 
 type resNode struct {
-	XMLName      xml.Name `xml:"res"`
-	Duration     string   `xml:"duration,attr,omitempty"`
-	ProtocolInfo string   `xml:"protocolInfo,attr"`
-	Value        string   `xml:",chardata"`
+	XMLName         xml.Name `xml:"res"`
+	Duration        string   `xml:"duration,attr,omitempty"`
+	Size            int64    `xml:"size,attr,omitempty"`
+	Bitrate         int      `xml:"bitrate,attr,omitempty"`
+	SampleFrequency int      `xml:"sampleFrequency,attr,omitempty"`
+	BitsPerSample   int      `xml:"bitsPerSample,attr,omitempty"`
+	NrAudioChannels int      `xml:"nrAudioChannels,attr,omitempty"`
+	ProtocolInfo    string   `xml:"protocolInfo,attr"`
+	Value           string   `xml:",chardata"`
 }
 
 type secCaptionInfo struct {
@@ -255,37 +265,45 @@ func buildURIMetadataPayload(media *MediaItem) ([]byte, error) {
 	}
 
 	var didl didLLiteItem
-	resNodeData := []resNode{}
-	//duration, _ := utils.DurationForMedia(media.URL)
 
-	if media.Duration == 0 {
-		resNodeData = append(resNodeData, resNode{
-			XMLName:      xml.Name{},
-			ProtocolInfo: fmt.Sprintf("http-get:*:%s:%s", media.ContentType, contentFeatures),
-			Value:        media.URL,
-		})
-	} else {
-		duration := utils.SecondsToClockTime(int(math.Round(media.Duration.Seconds())))
-		resNodeData = append(resNodeData, resNode{
-			XMLName:      xml.Name{},
-			Duration:     duration,
-			ProtocolInfo: fmt.Sprintf("http-get:*:%s:%s", media.ContentType, contentFeatures),
-			Value:        media.URL,
-		})
+	primary := resNode{
+		XMLName:         xml.Name{},
+		Size:            media.Size,
+		Bitrate:         media.Bitrate,
+		SampleFrequency: media.SampleFrequency,
+		BitsPerSample:   media.BitsPerSample,
+		NrAudioChannels: media.NrAudioChannels,
+		ProtocolInfo:    fmt.Sprintf("http-get:*:%s:%s", media.ContentType, contentFeatures),
+		Value:           media.URL,
 	}
+	if media.Duration > 0 {
+		primary.Duration = utils.SecondsToClockTime(int(math.Round(media.Duration.Seconds())))
+	}
+	resNodeData := []resNode{primary}
 
-	var title bytes.Buffer
-	if err := xml.EscapeText(&title, []byte(media.Title)); err != nil {
-		title.Reset()
+	// Pre-escape free-text fields so that the Samsung TV un-escape pass below
+	// leaves them XML-safe (xml.Marshal escapes them once, then the un-escape
+	// removes one layer, netting a single layer of escaping).
+	escape := func(s string) string {
+		var buf bytes.Buffer
+		if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+			return ""
+		}
+		return buf.String()
 	}
 	didl = didLLiteItem{
-		XMLName:    xml.Name{},
-		ID:         "1",
-		ParentID:   "0",
-		Restricted: "1",
-		UPNPClass:  class,
-		DCtitle:    title.String(),
-		ResNode:    resNodeData,
+		XMLName:              xml.Name{},
+		ID:                   "1",
+		ParentID:             "0",
+		Restricted:           "1",
+		UPNPClass:            class,
+		DCtitle:              escape(media.Title),
+		DCcreator:            escape(media.Artist),
+		UPNPartist:           escape(media.Artist),
+		UPNPalbum:            escape(media.Album),
+		UPNPoriginalTrackNum: media.TrackNumber,
+		UPNPalbumArtURI:      escape(media.AlbumArtURI),
+		ResNode:              resNodeData,
 	}
 
 	if strings.Contains(media.SubtitlesURL, "srt") {
@@ -294,25 +312,16 @@ func buildURIMetadataPayload(media *MediaItem) ([]byte, error) {
 			ProtocolInfo: "http-get:*:text/srt:*",
 			Value:        media.SubtitlesURL,
 		})
-
-		didl = didLLiteItem{
-			XMLName:    xml.Name{},
-			ID:         "1",
-			ParentID:   "0",
-			Restricted: "1",
-			DCtitle:    media.Title,
-			UPNPClass:  class,
-			ResNode:    resNodeData,
-			SecCaptionInfo: &secCaptionInfo{
-				XMLName: xml.Name{},
-				Type:    "srt",
-				Value:   media.SubtitlesURL,
-			},
-			SecCaptionInfoEx: &secCaptionInfoEx{
-				XMLName: xml.Name{},
-				Type:    "srt",
-				Value:   media.SubtitlesURL,
-			},
+		didl.ResNode = resNodeData
+		didl.SecCaptionInfo = &secCaptionInfo{
+			XMLName: xml.Name{},
+			Type:    "srt",
+			Value:   media.SubtitlesURL,
+		}
+		didl.SecCaptionInfoEx = &secCaptionInfoEx{
+			XMLName: xml.Name{},
+			Type:    "srt",
+			Value:   media.SubtitlesURL,
 		}
 	}
 

--- a/services/avtransport/requestbuilders_test.go
+++ b/services/avtransport/requestbuilders_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/supersonic-app/go-upnpcast/internal/utils"
 )
@@ -237,6 +238,66 @@ func TestSeekSoapBuild(t *testing.T) {
 				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildURIMetadataPayload_MusicMetadata(t *testing.T) {
+	media := &MediaItem{
+		Title:           "Needed Time",
+		Artist:          "Some Artist",
+		Album:           "Some Album",
+		AlbumArtURI:     "http://192.0.2.10:56736/art",
+		TrackNumber:     7,
+		URL:             "http://192.0.2.10:56736/stream",
+		ContentType:     "audio/x-dsf",
+		Seekable:        true,
+		Duration:        313 * time.Second,
+		Size:            221457176,
+		Bitrate:         5645000,
+		SampleFrequency: 2822400,
+		BitsPerSample:   1,
+		NrAudioChannels: 2,
+	}
+
+	contentFeatures, err := utils.BuildContentFeatures(media.ContentType, "01", false)
+	if err != nil {
+		t.Fatalf("BuildContentFeatures: %v", err)
+	}
+
+	want := `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Needed Time</dc:title><dc:creator>Some Artist</dc:creator><upnp:artist>Some Artist</upnp:artist><upnp:album>Some Album</upnp:album><upnp:originalTrackNumber>7</upnp:originalTrackNumber><upnp:albumArtURI>http://192.0.2.10:56736/art</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><res duration="00:05:13" size="221457176" bitrate="5645000" sampleFrequency="2822400" bitsPerSample="1" nrAudioChannels="2" protocolInfo="http-get:*:audio/x-dsf:` + contentFeatures + `">http://192.0.2.10:56736/stream</res></item></DIDL-Lite>`
+
+	got, err := buildURIMetadataPayload(media)
+	if err != nil {
+		t.Fatalf("buildURIMetadataPayload: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildURIMetadataPayload_AudioMinimal(t *testing.T) {
+	// When only the required fields are populated, no new metadata elements
+	// or <res> audio attributes should appear (omitempty path).
+	media := &MediaItem{
+		Title:       "Just A Title",
+		URL:         "http://192.0.2.10:56736/stream",
+		ContentType: "audio/flac",
+		Seekable:    true,
+	}
+
+	contentFeatures, err := utils.BuildContentFeatures(media.ContentType, "01", false)
+	if err != nil {
+		t.Fatalf("BuildContentFeatures: %v", err)
+	}
+
+	want := `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Just A Title</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><res protocolInfo="http-get:*:audio/flac:` + contentFeatures + `">http://192.0.2.10:56736/stream</res></item></DIDL-Lite>`
+
+	got, err := buildURIMetadataPayload(media)
+	if err != nil {
+		t.Fatalf("buildURIMetadataPayload: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("\ngot:  %s\nwant: %s", got, want)
 	}
 }
 


### PR DESCRIPTION
Extends `MediaItem` and the DIDL-Lite builder so callers can emit the full music-track metadata set that renderers expect for cover art, artist / album display, and stream format readouts.

Motivated by https://github.com/dweymouth/supersonic/issues/931: Supersonic's DLNA cast currently sends a minimal DIDL-Lite that omits `upnp:albumArtURI`, `dc:creator`, `upnp:artist`, `upnp:album`, `upnp:originalTrackNumber`, and the entire `<res>` audio-attribute set (`size`, `bitrate`, `sampleFrequency`, `bitsPerSample`, `nrAudioChannels`). The fix needs the library to expose those fields first; the supersonic-side wire-up will follow as a separate PR.

### Changes

**`MediaItem`**: adds `Artist`, `Album`, `AlbumArtURI`, `TrackNumber`, plus audio params for the `<res>` element (`Size`, `Bitrate`, `SampleFrequency`, `BitsPerSample`, `NrAudioChannels`). Bitrate follows the DIDL-Lite spec (bytes per second on `res@bitrate`).

**DIDL-Lite builder** (`buildURIMetadataPayload`): emits the new elements via `omitempty` so existing callers preserve their current output unchanged. The existing tests (subtitle + minimal video case) still pass without modification.

**Refactor**: folds all `<res>` attributes through a single primary node regardless of the `Duration` branch, which removes the `if Duration == 0` split and makes the subtitle path augment the DIDL instead of replacing it.

**Tests**: adds two cases to `requestbuilders_test.go` in the existing exact-match style:
- `TestBuildURIMetadataPayload_MusicMetadata` covers the fully populated case (artist, album, art URI, track number, duration, size, bitrate, sample rate, bit depth, channel count).
- `TestBuildURIMetadataPayload_AudioMinimal` locks the omitempty contract: title + URL + content type only produces the same minimal DIDL-Lite as before.

### Validation

Wired up end-to-end against a Plutinosoft Platinum SDK renderer (Eversolo DMP-A6) via a local supersonic branch. PCM 24/96 FLAC and native DSD64 both round-trip the new metadata correctly; the renderer renders cover art and reads back the populated `<res>` attributes (verified by snooping `GetMediaInfo` mid-playback). Same wire-snoop posted to https://github.com/dweymouth/supersonic/issues/931 for reference.

### Backward compatibility

All new `MediaItem` fields are added at the end of the struct; `omitempty` on the DIDL-Lite tags means a caller that doesn't populate them gets byte-identical output to today. The two new tests sit alongside the existing two without modification.